### PR TITLE
Update for 0.5 inbounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4
+julia 0.5
 Compat 0.19

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
   - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/RangeArrays.jl
+++ b/src/RangeArrays.jl
@@ -1,3 +1,4 @@
+__precompile__()
 module RangeArrays
 
 using Compat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,3 +59,18 @@ end
 @test R[:, 1:2] == RangeMatrix(1:10, 11:20)
 @test R[:, 1:4] == R[:,:] == RangeMatrix(1:10, 11:20, 21:30, 31:40)
 @test R[:, 3:4] == RangeMatrix(21:30, 31:40)
+
+A = 1:100
+@test_throws BoundsError A[RangeMatrix(0:9, 20:29)]
+@test_throws BoundsError A[RangeMatrix(20:29, 0:9)]
+@test_throws BoundsError A[RangeMatrix(20:29, 92:101)]
+@test_throws BoundsError A[RangeMatrix(92:101, 20:29)]
+@test_throws BoundsError A[RangeMatrix(-100:100)]
+@test A[RangeMatrix(1:10, 91:100)] == [1:10 91:100]
+
+@test_throws BoundsError A[RepeatedRangeMatrix(1:10, [-1,33])]
+@test_throws BoundsError A[RepeatedRangeMatrix(1:10, [33,-1])]
+@test_throws BoundsError A[RepeatedRangeMatrix(1:10, [91,33])]
+@test_throws BoundsError A[RepeatedRangeMatrix(1:10, [33,91])]
+@test_throws BoundsError A[RepeatedRangeMatrix(-100:100, [0])]
+@test A[RepeatedRangeMatrix(1:10, [0,90])] == [1:10 91:100]


### PR DESCRIPTION
* Take advantage of the 0.5 user-extensible boundschecking mechanism
* Add O(n) checkindex specialization when RangeArrays are used as indices (instead of the O(m*n) base implementation)
* Precompile
* Require Julia 0.5