### PR TITLE
Fix v0.7 deprecations and bump Compat and Julia version requirements.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.5
-Compat 0.19
+julia 0.6
+Compat 0.32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/repeatedrange.jl
+++ b/src/repeatedrange.jl
@@ -1,15 +1,16 @@
 """
-    RepeatedRangeMatrix{T}(r::Range{T}, at::AbstractVector{T})
+    RepeatedRangeMatrix(r::AbstractRange{T}, at::AbstractVector{T}) where T
 
 A RepeatedRange is like a RangeMatrix, except that it only stores one range and
 a vector of offsets, at which the range repeats. For now, both the range and
 vector of offsets must have the same element type.
 """
-immutable RepeatedRangeMatrix{T,R,A} <: AbstractMatrix{T}
+struct RepeatedRangeMatrix{T,R,A} <: AbstractMatrix{T}
     r::R # <: Range{T}
     at::A #<: AbstractVector{T}
 end
-RepeatedRangeMatrix{T}(r::Range{T}, at::AbstractVector{T}) = RepeatedRangeMatrix{T, typeof(r), typeof(at)}(r, at)
+RepeatedRangeMatrix(r::AbstractRange{T}, at::AbstractVector{T}) where T =
+    RepeatedRangeMatrix{T, typeof(r), typeof(at)}(r, at)
 
 Base.size(R::RepeatedRangeMatrix) = (length(R.r), length(R.at))
 @compat Base.IndexStyle(::Type{<:RepeatedRangeMatrix}) = IndexCartesian()
@@ -45,11 +46,11 @@ end
 
 # For non-scalar indexing, only specialize with inner Ranges and Colons to
 # return Ranges or RangeMatrixes. For everything else, we can use the fallbacks.
-@inline function Base.getindex(R::RepeatedRangeMatrix, I::Union{Range, Colon}, j::Real)
+@inline function Base.getindex(R::RepeatedRangeMatrix, I::Union{AbstractRange, Colon}, j::Real)
     @boundscheck checkbounds(R, I, j)
     @inbounds return R.r[I] + R.at[j]
 end
-@inline function Base.getindex(R::RepeatedRangeMatrix, I::Union{Range, Colon}, J)
+@inline function Base.getindex(R::RepeatedRangeMatrix, I::Union{AbstractRange, Colon}, J)
     @boundscheck checkbounds(R, I, J)
     @inbounds return RepeatedRangeMatrix(R.r[I], R.at[J])
 end


### PR DESCRIPTION
Self-explanatory, but do note that this PR drops support for Julia 0.5. I think this is reasonable since 0.5 is no longer officially supported.