### PR TITLE
Temporarily disable the iteration optimization on 0.7/1.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,18 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.6
+  - julia_version: 0.7
+  - julia_version: latest
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+#matrix:
+#  allow_failures:
+#  - julia_version: latest
 
 branches:
   only:
@@ -19,19 +26,12 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"RangeArrays\"); Pkg.build(\"RangeArrays\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"RangeArrays\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/src/repeatedrange.jl
+++ b/src/repeatedrange.jl
@@ -15,7 +15,9 @@ RepeatedRangeMatrix(r::AbstractRange{T}, at::AbstractVector{T}) where T =
 Base.size(R::RepeatedRangeMatrix) = (length(R.r), length(R.at))
 Base.IndexStyle(::Type{<:RepeatedRangeMatrix}) = IndexCartesian()
 
+if VERSION < v"0.7.0-DEV.5126"
 # This coupled iteration over the two fields is 10-20x faster than Cartesian iteration
+# TODO: re-implement in the new iteration protocol
 @inline function Base.start(R::RepeatedRangeMatrix)
     is = start(R.r)
     idone = done(R.r, is)
@@ -37,6 +39,7 @@ end
     return (val, (next(R.r, is), (j, js), false))
 end
 @inline Base.done(R::RepeatedRangeMatrix, state) = state[end]
+end
 
 # Scalar indexing
 @inline function Base.getindex(R::RepeatedRangeMatrix, i::Int, j::Int)


### PR DESCRIPTION
This was just an optimization, and should be completely re-written to take advantage of the new iteration protocol, but needs performance testing. Easy to just fall back to the default to get things passing in the mean-time.